### PR TITLE
Add sarif reporting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ FROM python:3-alpine
 ARG FLAKE8_VERSION
 
 RUN pip install flake8==$FLAKE8_VERSION
+RUN pip install flake8-sarif
 
 WORKDIR /apps
 


### PR DESCRIPTION
Hi!

The base installation of flake8 does not have custom formatters installed, this makes using flake8 in docker hard if the desired output format is not one of the two default formatters provided.

This pull-request is only based on my needs which is why only SARIF is considered, this obviously is valid for other types of formatters and other people who would find them useful should contribute as well.

If you don't find this contribution useful or if it dilutes the purpose of this repository to be a bare installation of flake8, I apologyse and will have to create a different solution for the usage of SARIF reporting within docker for flake8.